### PR TITLE
Feature/modify temp totrial

### DIFF
--- a/components/layout/SideBar.jsx
+++ b/components/layout/SideBar.jsx
@@ -1,9 +1,30 @@
+import React, { useEffect,useState } from "react";
 import styled from 'styled-components';
 import Link from 'next/link';
 import Cookies from 'universal-cookie';
 
+const cookies = new Cookies();
+
+const SideMenu = styled.ul`
+  li {
+    margin-bottom: 14px;
+    a {
+      color: #666666;
+      &.active {
+        color: #000;
+        font-weight: bold;
+      }
+    }
+  }
+`;
+
 export default ({ currentPath }) => {
-  const cookies = new Cookies();
+  const [showMailTemp, setShowMailTemp] = useState(true)
+  useEffect (()=>{
+    if (cookies.get('type') === "trial"){
+      setShowMailTemp(false)
+    }
+  })
 
   return (
     <div>
@@ -11,7 +32,7 @@ export default ({ currentPath }) => {
         <li>
           <a href='/'>検索事例 &gt;</a>
         </li>
-        { cookies.get('type') !== "trial" && (
+        { showMailTemp && (
         <li>
           <a href='/mail_templates'>メールテンプレート &gt;</a>
         </li>
@@ -43,16 +64,3 @@ export default ({ currentPath }) => {
     </div>
   );
 };
-
-const SideMenu = styled.ul`
-  li {
-    margin-bottom: 14px;
-    a {
-      color: #666666;
-      &.active {
-        color: #000;
-        font-weight: bold;
-      }
-    }
-  }
-`;

--- a/components/layout/SideBar.jsx
+++ b/components/layout/SideBar.jsx
@@ -1,16 +1,21 @@
 import styled from 'styled-components';
 import Link from 'next/link';
+import Cookies from 'universal-cookie';
 
 export default ({ currentPath }) => {
+  const cookies = new Cookies();
+
   return (
     <div>
       <SideMenu>
         <li>
           <a href='/'>検索事例 &gt;</a>
         </li>
+        { cookies.get('type') !== "trial" && (
         <li>
           <a href='/mail_templates'>メールテンプレート &gt;</a>
         </li>
+        )}
         <hr></hr>
         <li>
           <Link as='/documents/bs' href='/documents/bs'>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^16.9.0",
     "react-bootstrap": "^1.0.0-beta.12",
     "react-dom": "^16.9.0",
+    "universal-cookie": "^4.0.4",
     "styled-components": "^4.3.2",
     "wpapi": "^1.2.1",
     "react-youtube": "^7.13.1"

--- a/server.js
+++ b/server.js
@@ -31,8 +31,11 @@ app.prepare()
   server.get('/documents/:slug', (req, res) => {
     const actualPage = '/documents';
     const queryParams = { slug: req.params.slug };
+    if(req.query.type){
+      res.cookie("type", "trial", {maxAge: 600000});
+    };
     app.render(req, res, actualPage, queryParams);
-  })
+  });
 
   server.get('/', (req, res) => {
     const actualPage = '/';

--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ app.prepare()
     const actualPage = '/documents';
     const queryParams = { slug: req.params.slug };
     if(req.query.type){
-      res.cookie("type", "trial", {maxAge: 600000});
+      res.cookie("type", "trial", {maxAge: 1800000});
     };
     app.render(req, res, actualPage, queryParams);
   });


### PR DESCRIPTION
## 修正内容
- お試しユーザーは、ガイドのメールテンプレートを見えないようにする

## 仕様
- FutureSearchのBS/CA/DPから「使い方について」をクリックするとガイドが開かれるが、お試しユーザーの場合は?type=trialのパラメータが送信されます
- ガイドでは、クエリパラメータがある場合Cookieに30分間保存され、そのパラメータがある限りメールテンプレートが表示されないようにしてます